### PR TITLE
Fixed unescaped path issue in interceptors location for Windows environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ orleans.codegen.cs
 .idea/
 *.sln.iml
 BenchmarkDotNet.Artifacts/
+
+# Test snapshots
+**/*.received.*

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging.AutoLoggerMessage
     {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         [System.Runtime.CompilerServices.InterceptsLocationAttribute(
-            filePath: "file",
+            filePath: @"file",
             line: 1, character: 11)]
         public static void Log_namespace1class1_1_11(this ILogger @logger, string @message)
         {
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging.AutoLoggerMessage
         
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         [System.Runtime.CompilerServices.InterceptsLocationAttribute(
-            filePath: "file2",
+            filePath: @"file2",
             line: 2, character: 22)]
         public static void Log_namespace2class2_2_22(this ILogger @logger, string @message, int @intParam)
         {
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Logging.AutoLoggerMessage
         
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         [System.Runtime.CompilerServices.InterceptsLocationAttribute(
-            filePath: "file3",
+            filePath: @"file3",
             line: 3, character: 33)]
         public static void Log_namespace3class3_3_33(this ILogger @logger, string @message, int @intParam, bool @boolParam, SomeClass @objectParam)
         {

--- a/src/AutoLoggerMessageGenerator/Emitters/LoggerInterceptorsEmitter.cs
+++ b/src/AutoLoggerMessageGenerator/Emitters/LoggerInterceptorsEmitter.cs
@@ -7,7 +7,7 @@ using AutoLoggerMessageGenerator.Utilities;
 
 namespace AutoLoggerMessageGenerator.Emitters;
 
-internal class LoggerInterceptorsEmitter
+internal static class LoggerInterceptorsEmitter
 {
     public static string Emit(IEnumerable<LogCall> logCalls)
     {
@@ -32,7 +32,7 @@ internal class LoggerInterceptorsEmitter
             sb.WriteLine(Constants.EditorNotBrowsableAttribute);
             sb.WriteLine($"[{Constants.InterceptorNamespace}.{Constants.InterceptorAttributeName}(");
             sb.Indent++;
-            sb.WriteLine($"filePath: \"{logCall.Location.FilePath}\",");
+            sb.WriteLine($"filePath: @\"{logCall.Location.FilePath}\",");
             sb.WriteLine($"line: {logCall.Location.Line}, character: {logCall.Location.Character})]");
             sb.Indent--;
 


### PR DESCRIPTION
Resolved the #1 issue with escaping interceptor location 