### PR TITLE
Updated filePath-based intercept location attribute with hash-based

### DIFF
--- a/src/AutoLoggerMessageGenerator.UnitTests/AutoLoggerMessageGenerator.UnitTests.csproj
+++ b/src/AutoLoggerMessageGenerator.UnitTests/AutoLoggerMessageGenerator.UnitTests.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.2"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AutoLoggerMessageGenerator.UnitTests/Caching/InputSourceComparerTests.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Caching/InputSourceComparerTests.cs
@@ -18,7 +18,7 @@ public class InputSourceComparerTests
     {
         var compilation1 = CSharpCompilation.Create(default);
         var compilation2 = CSharpCompilation.Create(default);
-        
+
         var inputSource1  = CreateInputSource(compilation: compilation1);
         var inputSource2 = CreateInputSource(compilation: compilation2);
 
@@ -26,13 +26,13 @@ public class InputSourceComparerTests
 
         sut.Equals(inputSource1, inputSource2).Should().BeTrue();
     }
-    
+
     [Fact]
     public void Equals_WithDifferentConfiguration_ShouldReturnFalse()
     {
         var configuration1 = new SourceGeneratorConfiguration(true, true, true, true, true);
         var configuration2 = new SourceGeneratorConfiguration(false, false, false, false, false);
-        
+
         var inputSource1  = CreateInputSource(configuration: configuration1);
         var inputSource2 = CreateInputSource(configuration: configuration2);
 
@@ -40,17 +40,17 @@ public class InputSourceComparerTests
 
         sut.Equals(inputSource1, inputSource2).Should().BeFalse();
     }
-    
+
     [Theory]
     [InlineData("ref1", "1.0.0", "ref2", "1.0.0")]
     [InlineData("ref1", "1.0.0", "ref1", "2.0.0")]
     public void Equals_WithDifferentReferences_ShouldReturnFalse(
-        string reference1Name, string reference1Version, 
+        string reference1Name, string reference1Version,
         string reference2Name, string reference2Version)
     {
         ImmutableArray<Reference> references1 = [new Reference(reference1Name, new Version(reference1Version))];
         ImmutableArray<Reference> references2 = [new Reference(reference2Name, new Version(reference2Version))];
-        
+
         var inputSource1  = CreateInputSource(references: references1);
         var inputSource2 = CreateInputSource(references: references2);
 
@@ -58,13 +58,13 @@ public class InputSourceComparerTests
 
         sut.Equals(inputSource1, inputSource2).Should().BeFalse();
     }
-    
+
     [Fact]
     public void Equals_WithDifferentLogCalls_ShouldReturnFalse()
     {
         ImmutableArray<LogCall> logCalls = [new LogCall { Message = "message1"}];
         ImmutableArray<LogCall> logCalls2 = [new LogCall { Message = "message2"}];
-        
+
         var inputSource1  = CreateInputSource(logCalls: logCalls);
         var inputSource2 = CreateInputSource(logCalls: logCalls2);
 
@@ -73,9 +73,9 @@ public class InputSourceComparerTests
         sut.Equals(inputSource1, inputSource2).Should().BeFalse();
     }
 
-    private static InputSource CreateInputSource(Compilation? compilation = default, 
+    private static InputSource CreateInputSource(Compilation? compilation = default,
         SourceGeneratorConfiguration? configuration = default,
-        ImmutableArray<Reference>? references = default, 
+        ImmutableArray<Reference>? references = default,
         ImmutableArray<LogCall>? logCalls = default)
     {
         compilation ??= CSharpCompilation.Create(default);
@@ -83,7 +83,7 @@ public class InputSourceComparerTests
         references ??= [new Reference("some lib", new Version("1.2.3"))];
         logCalls ??=
         [
-            new LogCall(Guid.NewGuid(), new LogCallLocation("some file", 1, 2, Location.None), "namespace", "class", "name",
+            new LogCall(Guid.NewGuid(), MockLogCallLocationBuilder.Build("some file", 1, 2), "namespace", "class", "name",
                 "information", "message", [])
         ];
 

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/InterceptorAttributeEmitterTests.Emit_ShouldGenerateValidInterceptorAttribute.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/InterceptorAttributeEmitterTests.Emit_ShouldGenerateValidInterceptorAttribute.verified.txt
@@ -10,6 +10,6 @@ namespace System.Runtime.CompilerServices
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     internal sealed class InterceptsLocationAttribute : Attribute
     {
-        public InterceptsLocationAttribute(string filePath, int line, int character) {}
+        public InterceptsLocationAttribute(int version, string data) {}
     }
 }

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
@@ -12,27 +12,21 @@ namespace Microsoft.Extensions.Logging.AutoLoggerMessage
     internal static class LoggerInterceptors
     {
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
-        [System.Runtime.CompilerServices.InterceptsLocationAttribute(
-            filePath: @"file",
-            line: 1, character: 11)]
+        [FakeInterceptableLocation(-1, "ZmlsZSgxLDExKQ==")]
         public static void Log_namespace1class1_1_11(this ILogger @logger, string @message)
         {
             Microsoft.Extensions.Logging.AutoLoggerMessage.AutoLoggerMessage.Log_namespace1class1_1_11(@logger);
         }
         
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
-        [System.Runtime.CompilerServices.InterceptsLocationAttribute(
-            filePath: @"file2",
-            line: 2, character: 22)]
+        [FakeInterceptableLocation(-1, "ZmlsZTIoMiwyMik=")]
         public static void Log_namespace2class2_2_22(this ILogger @logger, string @message, int @intParam)
         {
             Microsoft.Extensions.Logging.AutoLoggerMessage.AutoLoggerMessage.Log_namespace2class2_2_22(@logger, @intParam);
         }
         
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
-        [System.Runtime.CompilerServices.InterceptsLocationAttribute(
-            filePath: @"file3",
-            line: 3, character: 33)]
+        [FakeInterceptableLocation(-1, "ZmlsZTMoMywzMyk=")]
         public static void Log_namespace3class3_3_33(this ILogger @logger, string @message, int @intParam, bool @boolParam, SomeClass @objectParam)
         {
             Microsoft.Extensions.Logging.AutoLoggerMessage.AutoLoggerMessage.Log_namespace3class3_3_33(@logger, @intParam, @boolParam, @objectParam);

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using AutoLoggerMessageGenerator.Emitters;
 using AutoLoggerMessageGenerator.Models;
-using Microsoft.CodeAnalysis;
 using static AutoLoggerMessageGenerator.Constants;
 
 namespace AutoLoggerMessageGenerator.UnitTests.Emitters;
@@ -15,7 +14,7 @@ public class LoggerInterceptorsEmitterTests
         [
             new LogCall(
                 Id: Guid.NewGuid(),
-                Location: new LogCallLocation("file", 1, 11, Location.None),
+                Location: MockLogCallLocationBuilder.Build("file", 1, 11),
                 Namespace: "namespace1",
                 ClassName: "class1",
                 Name: "name1",
@@ -25,7 +24,7 @@ public class LoggerInterceptorsEmitterTests
             ),
             new LogCall(
                 Id: Guid.NewGuid(),
-                Location: new LogCallLocation("file2", 2, 22, Location.None),
+                Location: MockLogCallLocationBuilder.Build("file2", 2, 22),
                 Namespace: "namespace2",
                 ClassName: "class2",
                 Name: "name2",
@@ -38,7 +37,7 @@ public class LoggerInterceptorsEmitterTests
             ),
             new LogCall(
                 Id: Guid.NewGuid(),
-                Location: new LogCallLocation("file3", 3, 33, Location.None),
+                Location: MockLogCallLocationBuilder.Build("file3", 3, 33),
                 Namespace: "namespace3",
                 ClassName: "class3",
                 Name: "name3",

--- a/src/AutoLoggerMessageGenerator.UnitTests/Extractors/LogCallExtractorTests.Extract_WithLogMethodInvocationCode_ShouldTransformThemIntoLogCallObject.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Extractors/LogCallExtractorTests.Extract_WithLogMethodInvocationCode_ShouldTransformThemIntoLogCallObject.verified.txt
@@ -4,6 +4,7 @@
     FilePath: ,
     Line: 12,
     Character: 16,
+    InterceptableLocationSyntax: [global::System.Runtime.CompilerServices.InterceptsLocationAttribute(1, "bg8SAsBDKqh7V1TqOZu8tZkAAAA=")],
     Context: {
       Kind: SourceFile,
       SourceSpan: {
@@ -15,7 +16,7 @@
         Length: 214,
         HasCompilationUnitRoot: true,
         Options: {
-          LanguageVersion: CSharp12,
+          LanguageVersion: CSharp13,
           Language: C#,
           DocumentationMode: Parse,
           Errors: null

--- a/src/AutoLoggerMessageGenerator.UnitTests/MockLogCallLocationBuilder.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/MockLogCallLocationBuilder.cs
@@ -1,0 +1,20 @@
+using System.Text;
+using AutoLoggerMessageGenerator.Models;
+using Microsoft.CodeAnalysis;
+
+namespace AutoLoggerMessageGenerator.UnitTests;
+
+internal static class MockLogCallLocationBuilder
+{
+    public static LogCallLocation Build(string filePath, int line, int character)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(filePath);
+
+        const int version = -1;
+        var location = $"{filePath}({line},{character})";
+        var data = Convert.ToBase64String(Encoding.UTF8.GetBytes(location));
+        var interceptableLocationSyntax = $"""[FakeInterceptableLocation({version}, "{data}")]""";
+
+        return new LogCallLocation(filePath, line, character, interceptableLocationSyntax, Location.None);
+    }
+}

--- a/src/AutoLoggerMessageGenerator.UnitTests/VirtualLoggerMessage/VirtualLoggerMessageClassBuilderTests.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/VirtualLoggerMessage/VirtualLoggerMessageClassBuilderTests.cs
@@ -44,7 +44,7 @@ public class VirtualLoggerMessageClassBuilderTests
             _logCall with
             {
                 Id = Guid.NewGuid(),
-                Location = new LogCallLocation("path/to/another/file.cs", 3, 33, Location.None),
+                Location = MockLogCallLocationBuilder.Build("path/to/another/file.cs", 3, 33),
                 Message = "Goodbye, World!",
                 LogLevel = "Trace"
             }
@@ -67,7 +67,7 @@ public class VirtualLoggerMessageClassBuilderTests
             _logCall with
             {
                 Id = Guid.NewGuid(),
-                Location = new LogCallLocation("path/to/another/file.cs", 3, 33, Location.None),
+                Location = MockLogCallLocationBuilder.Build("path/to/another/file.cs", 3, 33),
                 Message = "All characters should be passed as a string literal expression: \n\r\t",
                 LogLevel = "Trace"
             }

--- a/src/AutoLoggerMessageGenerator/Analysers/InvalidTemplateParameterNameAnalyser.cs
+++ b/src/AutoLoggerMessageGenerator/Analysers/InvalidTemplateParameterNameAnalyser.cs
@@ -58,7 +58,7 @@ public class InvalidTemplateParameterNameAnalyser : DiagnosticAnalyzer
         if (!templateParameterNames.Any())
             return;
 
-        var location = LogCallLocationMapper.Map(invocationExpression);
+        var location = LogCallLocationMapper.Map(semanticModel, invocationExpression);
         if (location is null)
             return;
 

--- a/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.csproj
+++ b/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
   </ItemGroup>
 

--- a/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.csproj
+++ b/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.csproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <NoWarn>RSEXPERIMENTAL002</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -27,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
   </ItemGroup>
 

--- a/src/AutoLoggerMessageGenerator/Emitters/InterceptorAttributeEmitter.cs
+++ b/src/AutoLoggerMessageGenerator/Emitters/InterceptorAttributeEmitter.cs
@@ -22,7 +22,7 @@ internal static class InterceptorAttributeEmitter
         sb.WriteLine('{');
         sb.Indent++;
 
-        sb.WriteLine($"public {Constants.InterceptorAttributeName}(string filePath, int line, int character) {{}}");
+        sb.WriteLine($"public {Constants.InterceptorAttributeName}(int version, string data) {{}}");
 
         sb.Indent--;
         sb.WriteLine('}');
@@ -30,6 +30,6 @@ internal static class InterceptorAttributeEmitter
         sb.Indent--;
         sb.WriteLine('}');
 
-        return sb.InnerWriter.ToString();
+        return sb.InnerWriter.ToString()!;
     }
 }

--- a/src/AutoLoggerMessageGenerator/Emitters/LoggerInterceptorsEmitter.cs
+++ b/src/AutoLoggerMessageGenerator/Emitters/LoggerInterceptorsEmitter.cs
@@ -30,11 +30,7 @@ internal static class LoggerInterceptorsEmitter
         foreach (var logCall in logCalls)
         {
             sb.WriteLine(Constants.EditorNotBrowsableAttribute);
-            sb.WriteLine($"[{Constants.InterceptorNamespace}.{Constants.InterceptorAttributeName}(");
-            sb.Indent++;
-            sb.WriteLine($"filePath: @\"{logCall.Location.FilePath}\",");
-            sb.WriteLine($"line: {logCall.Location.Line}, character: {logCall.Location.Character})]");
-            sb.Indent--;
+            sb.WriteLine(logCall.Location.InterceptableLocationSyntax);
 
             var parameters = string.Join(", ", logCall.Parameters.Select((c, i) => $"{c.NativeType} {c.Name}"));
             parameters = string.IsNullOrEmpty(parameters) ? string.Empty : $", {parameters}";
@@ -65,6 +61,6 @@ internal static class LoggerInterceptorsEmitter
         sb.Indent--;
         sb.WriteLine('}');
 
-        return sb.InnerWriter.ToString();
+        return sb.InnerWriter.ToString()!;
     }
 }

--- a/src/AutoLoggerMessageGenerator/Extractors/LogCallExtractor.cs
+++ b/src/AutoLoggerMessageGenerator/Extractors/LogCallExtractor.cs
@@ -14,7 +14,8 @@ internal static class LogCallExtractor
         SemanticModel semanticModel)
     {
         var (ns, className) = LogCallCallerExtractor.Extract(invocationExpression);
-        var location = LogCallLocationMapper.Map(invocationExpression);
+
+        var location = LogCallLocationMapper.Map(semanticModel, invocationExpression);
         if (location is null)
             return default;
 

--- a/src/AutoLoggerMessageGenerator/Mappers/LogCallLocationMapper.cs
+++ b/src/AutoLoggerMessageGenerator/Mappers/LogCallLocationMapper.cs
@@ -1,14 +1,20 @@
 using AutoLoggerMessageGenerator.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace AutoLoggerMessageGenerator.Mappers;
 
 internal static class LogCallLocationMapper
 {
-    public static LogCallLocation? Map(InvocationExpressionSyntax invocationExpression)
+    public static LogCallLocation? Map(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression)
     {
         var memberAccessExpression = invocationExpression.Expression as MemberAccessExpressionSyntax;
         if (memberAccessExpression?.Expression is not IdentifierNameSyntax identifierName)
+            return null;
+
+        var interceptableLocation = semanticModel.GetInterceptableLocation(invocationExpression);
+        if (interceptableLocation is null)
             return null;
 
         var skipSymbols = identifierName.Identifier.ValueText.Length + 1; // obj accessor + dot symbol
@@ -20,6 +26,7 @@ internal static class LogCallLocationMapper
         return new LogCallLocation(lineSpan.Path,
             lineSpan.StartLinePosition.Line + 1,
             linePositionSpan.Start.Character + skipSymbols + 1,
+            InterceptableLocationSyntax: interceptableLocation.GetInterceptsLocationAttributeSyntax(),
             Context: location
         );
     }

--- a/src/AutoLoggerMessageGenerator/Models/LogCallLocation.cs
+++ b/src/AutoLoggerMessageGenerator/Models/LogCallLocation.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.CodeAnalysis;
 
 namespace AutoLoggerMessageGenerator.Models;
@@ -6,22 +7,18 @@ internal readonly record struct LogCallLocation(
     string FilePath,
     int Line,
     int Character,
+    string InterceptableLocationSyntax,
     Location Context
 )
 {
     public readonly bool Equals(LogCallLocation other) =>
         FilePath == other.FilePath &&
         Line == other.Line &&
-        Character == other.Character;
+        Character == other.Character &&
+        InterceptableLocationSyntax == other.InterceptableLocationSyntax;
 
-    public readonly override int GetHashCode()
+    public override int GetHashCode()
     {
-        unchecked
-        {
-            var hashCode = FilePath.GetHashCode();
-            hashCode = (hashCode * 397) ^ Line;
-            hashCode = (hashCode * 397) ^ Character;
-            return hashCode;
-        }
+        return HashCode.Combine(FilePath, Line, Character, InterceptableLocationSyntax);
     }
 }


### PR DESCRIPTION
> In prior experimental releases of the feature, a well-known constructor signature `InterceptsLocation(string path, int line, int column)]` was also supported. Support for this constructor will be **dropped** prior to stable release of the feature.

([source](https://github.com/dotnet/roslyn/pull/72814/files/3f1a038cfee3cb42a648837de8b74a1146424968#diff-eef9e4c724788e9db96f07567a9894bbb2da020ec59a2ded58b7f22bd175a1a1R69))