### PR TITLE
Replaced package version with project version in order to write the correct version number in the generated files

### DIFF
--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/InterceptorAttributeEmitterTests.Emit_ShouldGenerateValidInterceptorAttribute.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/InterceptorAttributeEmitterTests.Emit_ShouldGenerateValidInterceptorAttribute.verified.txt
@@ -5,7 +5,7 @@ using System;
 
 namespace System.Runtime.CompilerServices
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("AutoLoggerMessageGenerator", "1.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("AutoLoggerMessageGenerator", "1.2.3.4")]
     [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     internal sealed class InterceptsLocationAttribute : Attribute

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/InterceptorAttributeEmitterTests.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/InterceptorAttributeEmitterTests.cs
@@ -1,4 +1,5 @@
 using AutoLoggerMessageGenerator.Emitters;
+using AutoLoggerMessageGenerator.UnitTests.Scrubbers;
 
 namespace AutoLoggerMessageGenerator.UnitTests.Emitters;
 
@@ -8,7 +9,6 @@ internal class InterceptorAttributeEmitterTests
     public async Task Emit_ShouldGenerateValidInterceptorAttribute()
     {
         var sourceCode = InterceptorAttributeEmitter.Emit();
-
-        await Verify(sourceCode);
+        await Verify(sourceCode).AddCodeGeneratedAttributeScrubber();
     }
 }

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerExtensionsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerExtensionsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.Logging
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("AutoLoggerMessageGenerator", "1.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("AutoLoggerMessageGenerator", "1.2.3.4")]
     [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     [System.Diagnostics.DebuggerStepThrough]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerExtensionsEmitterTests.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerExtensionsEmitterTests.cs
@@ -1,4 +1,5 @@
 using AutoLoggerMessageGenerator.Emitters;
+using AutoLoggerMessageGenerator.UnitTests.Scrubbers;
 
 namespace AutoLoggerMessageGenerator.UnitTests.Emitters;
 
@@ -8,6 +9,6 @@ internal class LoggerExtensionsEmitterTests
     public async Task Emit_ShouldGenerateValidLoggingExtensionsAttribute()
     {
         var sourceCode = LoggerExtensionsEmitter.Emit();
-        await Verify(sourceCode);
+        await Verify(sourceCode).AddCodeGeneratedAttributeScrubber();
     }
 }

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.Emit_ShouldGenerateValidLoggingExtensionsAttribute.verified.txt
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.Logging.AutoLoggerMessage
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("AutoLoggerMessageGenerator", "1.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("AutoLoggerMessageGenerator", "1.2.3.4")]
     [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [System.Diagnostics.DebuggerStepThrough]

--- a/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Emitters/LoggerInterceptorsEmitterTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using AutoLoggerMessageGenerator.Emitters;
 using AutoLoggerMessageGenerator.Models;
+using AutoLoggerMessageGenerator.UnitTests.Scrubbers;
 using static AutoLoggerMessageGenerator.Constants;
 
 namespace AutoLoggerMessageGenerator.UnitTests.Emitters;
@@ -53,6 +54,6 @@ internal class LoggerInterceptorsEmitterTests
         ];
 
         var sourceCode = LoggerInterceptorsEmitter.Emit(logCalls);
-        await Verify(sourceCode);
+        await Verify(sourceCode).AddCodeGeneratedAttributeScrubber();
     }
 }

--- a/src/AutoLoggerMessageGenerator.UnitTests/Scrubbers/GeneratedCodeAttributeScrubber.cs
+++ b/src/AutoLoggerMessageGenerator.UnitTests/Scrubbers/GeneratedCodeAttributeScrubber.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace AutoLoggerMessageGenerator.UnitTests.Scrubbers;
+
+public static partial class GeneratedCodeAttributeScrubber
+{
+    [GeneratedRegex($""""{nameof(AutoLoggerMessageGenerator)}", "\d+.\d+.\d+.\d?"""")]
+    private static partial Regex GeneratedCodeAttributeVersionRegex();
+
+    public static SettingsTask AddCodeGeneratedAttributeScrubber(this SettingsTask task)
+    {
+        task.ScrubLinesWithReplace(line => GeneratedCodeAttributeVersionRegex().Replace(
+            line,
+            $""""{nameof(AutoLoggerMessageGenerator)}", "1.2.3.4""""));
+        return task;
+    }
+}

--- a/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.csproj
+++ b/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.csproj
@@ -7,11 +7,11 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
     <NoWarn>RSEXPERIMENTAL002;RS2008</NoWarn>
+    <Version>1.0.8</Version>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>stbychkov.AutoLoggerMessage</PackageId>
-    <PackageVersion>1.0.8</PackageVersion>
     <Authors>stbychkov</Authors>
     <Title>AutoLoggerMessage</Title>
     <Description>A source generator that automatically migrates your logging calls to the LoggerMessage version</Description>


### PR DESCRIPTION
Currently, all generated files include the `GeneratedCodeAttribute`, but the version specified in this attribute is always `1.0.0.0`. That happens because only the `PackageVersion` is currently being specified, while the project version defaults to the initial value. Replace `PackageVersion` attribute with the `Version` attribute should apply the correct version to both the package and the project