### PR TITLE
Skipped log calls with generic arguments due to LoggerMessage constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Take a look at [benchmark](https://github.com/stbychkov/AutoLoggerMessage/wiki/B
   so if you pass more than that, the default `Logger.Log(*, params object[] args)` will be executed.
 * As this solution is based on interceptors, only .NET 8+ is supported
 * Hash-based interceptors are incompatible with .NET SDK versions earlier than 8.0.8, most likely due to differences in the compiler version. To resolve this issue, please update your SDK to version [8.0.8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later.
+* Generic arguments are https://github.com/dotnet/extensions/blob/ca2fe808b3d6c55817467f46ca58657456b4a928/docs/list-of-diagnostics.md?plain=1#L66C4-L66C13. If you pass a generic argument to the log function, the default `Logger.Log(*, params object[] args)` will be executed.
 
 ## Is something wrong?
 

--- a/src/AutoLoggerMessageGenerator/Extractors/LogCallParametersExtractor.cs
+++ b/src/AutoLoggerMessageGenerator/Extractors/LogCallParametersExtractor.cs
@@ -27,6 +27,10 @@ internal class LogCallParametersExtractor(LogPropertiesCheck? logPropertiesCheck
         if (templateParametersNames.Length < methodParameters.Length)
             return null;
 
+        // https://github.com/dotnet/extensions/blob/ca2fe808b3d6c55817467f46ca58657456b4a928/docs/list-of-diagnostics.md?plain=1#L66C4-L66C13
+        if (methodParameters.Any(IsGenericParameter))
+            return null;
+
         var uniqueNameSuffix = ReservedParameterNameResolver.GenerateUniqueIdentifierSuffix(templateParametersNames);
 
         var utilityParameters = methodSymbol.Parameters
@@ -70,4 +74,7 @@ internal class LogCallParametersExtractor(LogPropertiesCheck? logPropertiesCheck
 
     private static string TransformParameterName(string parameterName) =>
         parameterName.StartsWith("@") ? parameterName : '@' + parameterName;
+
+    private static bool IsGenericParameter(IParameterSymbol parameterSymbol) =>
+        parameterSymbol.Type is INamedTypeSymbol { IsGenericType: true } or ITypeParameterSymbol;
 }


### PR DESCRIPTION
Context: LoggerMessage [doesn't support](https://github.com/dotnet/extensions/blob/ca2fe808b3d6c55817467f46ca58657456b4a928/docs/list-of-diagnostics.md?plain=1#L66C4-L66C13) generic arguments out-of-the-box

Solution: skip all log calls that have generic arguments