### PR TITLE
Ensured AutoLoggerMessage DLL is included in publish output

### DIFF
--- a/src/AutoLoggerMessageGenerator.Sandbox/AutoLoggerMessageGenerator.Sandbox.csproj
+++ b/src/AutoLoggerMessageGenerator.Sandbox/AutoLoggerMessageGenerator.Sandbox.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.Build.targets
+++ b/src/AutoLoggerMessageGenerator/AutoLoggerMessageGenerator.Build.targets
@@ -5,7 +5,7 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <NoWarn>RSEXPERIMENTAL002;RS2008</NoWarn>
     <Version>1.0.10</Version>
-    <DevelopmentDependency>true</DevelopmentDependency>
+    <DevelopmentDependency>false</DevelopmentDependency>
     <AssemblyName>AutoLoggerMessageGenerator</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>


### PR DESCRIPTION
`<DevelopmentDependency>true</DevelopmentDependency>` in the package metadata treats the package as a development-only dependency, which further prevents it from being copied to the output directory at publish time.