### PR TITLE
Generated default event id and name based on the provided values

### DIFF
--- a/src/AutoLoggerMessageGenerator/Configuration/GeneratorOptionsProvider.cs
+++ b/src/AutoLoggerMessageGenerator/Configuration/GeneratorOptionsProvider.cs
@@ -1,3 +1,4 @@
+using AutoLoggerMessageGenerator.Models;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -12,6 +13,8 @@ internal static class GeneratorOptionsProvider
     private const string GenerateSkipNullPropertiesKey = $"{CommonPrefix}_{nameof(SourceGeneratorConfiguration.GenerateSkipNullProperties)}";
     private const string GenerateTransitiveKey = $"{CommonPrefix}_{nameof(SourceGeneratorConfiguration.GenerateTransitive)}";
     private const string OverrideBeginScopeBehaviorKey = $"{CommonPrefix}_{nameof(SourceGeneratorConfiguration.OverrideBeginScopeBehavior)}";
+    private const string DefaultEventIdKey = $"{CommonPrefix}_{nameof(SourceGeneratorConfiguration.DefaultEventId)}";
+    private const string DefaultEventNameKey = $"{CommonPrefix}_{nameof(SourceGeneratorConfiguration.DefaultEventId)}_Name";
 
     public static IncrementalValueProvider<SourceGeneratorConfiguration> Provide(IncrementalGeneratorInitializationContext context) =>
         context.AnalyzerConfigOptionsProvider.Select((options, _) => new SourceGeneratorConfiguration(
@@ -20,7 +23,8 @@ internal static class GeneratorOptionsProvider
             GenerateOmitReferenceName: GetValue(options.GlobalOptions, GenerateOmitReferenceNameKey, false),
             GenerateSkipNullProperties: GetValue(options.GlobalOptions, GenerateSkipNullPropertiesKey, false),
             GenerateTransitive: GetValue(options.GlobalOptions, GenerateTransitiveKey, false),
-            OverrideBeginScopeBehavior: GetValue(options.GlobalOptions, OverrideBeginScopeBehaviorKey, true)
+            OverrideBeginScopeBehavior: GetValue(options.GlobalOptions, OverrideBeginScopeBehaviorKey, true),
+            DefaultEventId: GetDefaultEventId(options.GlobalOptions)
         ));
 
     private static bool GetValue(AnalyzerConfigOptions options, string key, bool defaultValue = true) =>
@@ -31,4 +35,15 @@ internal static class GeneratorOptionsProvider
         || StringComparer.OrdinalIgnoreCase.Equals("enabled", value)
         || StringComparer.OrdinalIgnoreCase.Equals("true", value)
         || (bool.TryParse(value, out var boolVal) ? boolVal : defaultValue);
+
+    private static EventId? GetDefaultEventId(AnalyzerConfigOptions options)
+    {
+        if (options.TryGetValue(DefaultEventIdKey, out var defaultEventIdString) is false ||
+            int.TryParse(defaultEventIdString, out var parsedDefaultEventId) is false)
+            return null;
+
+        options.TryGetValue(DefaultEventNameKey, out var eventName);
+
+        return new EventId(parsedDefaultEventId, eventName);
+    }
 }

--- a/src/AutoLoggerMessageGenerator/Configuration/SourceGeneratorConfiguration.cs
+++ b/src/AutoLoggerMessageGenerator/Configuration/SourceGeneratorConfiguration.cs
@@ -1,3 +1,5 @@
+using AutoLoggerMessageGenerator.Models;
+
 namespace AutoLoggerMessageGenerator.Configuration;
 
 internal record struct SourceGeneratorConfiguration
@@ -9,5 +11,6 @@ internal record struct SourceGeneratorConfiguration
     bool GenerateOmitReferenceName,
     bool GenerateSkipNullProperties,
     bool GenerateTransitive,
-    bool OverrideBeginScopeBehavior
+    bool OverrideBeginScopeBehavior,
+    EventId? DefaultEventId = null
 );

--- a/src/AutoLoggerMessageGenerator/Generators/AutoLoggerMessageGenerator.LoggerMessage.cs
+++ b/src/AutoLoggerMessageGenerator/Generators/AutoLoggerMessageGenerator.LoggerMessage.cs
@@ -20,8 +20,10 @@ namespace AutoLoggerMessageGenerator.Generators;
 
 public partial class AutoLoggerMessageGenerator
 {
-    private static void GenerateLoggerMessages(IncrementalGeneratorInitializationContext context,
-        IncrementalValueProvider<SourceGeneratorConfiguration> configuration, IncrementalValueProvider<ImmutableArray<Reference>> modulesProvider)
+    private static void GenerateLoggerMessages(
+        IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<SourceGeneratorConfiguration> configuration,
+        IncrementalValueProvider<ImmutableArray<Reference>> modulesProvider)
     {
         var logCallsProvider = context.SyntaxProvider.CreateSyntaxProvider(
                 LogMessageCallFilter.IsLogCallInvocation,

--- a/src/AutoLoggerMessageGenerator/Models/EventId.cs
+++ b/src/AutoLoggerMessageGenerator/Models/EventId.cs
@@ -1,0 +1,3 @@
+namespace AutoLoggerMessageGenerator.Models;
+
+internal record struct EventId(int Id, string? Name);

--- a/src/AutoLoggerMessageGenerator/VirtualLoggerMessage/VirtualLoggerMessageClassBuilder.cs
+++ b/src/AutoLoggerMessageGenerator/VirtualLoggerMessage/VirtualLoggerMessageClassBuilder.cs
@@ -67,22 +67,38 @@ internal class VirtualLoggerMessageClassBuilder(
 
     private AttributeListSyntax GenerateLoggerMessageAttribute(LogMessageCall logMessageCall)
     {
+        var attributeArguments = SeparatedList(new[]
+            {
+                AttributeArgument(
+                    ParseExpression(
+                        $"Level = {Constants.DefaultLoggingNamespace}.LogLevel.{logMessageCall.LogLevel}")),
+                AttributeArgument(
+                    AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName("Message"),
+                        LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(logMessageCall.Message)))),
+                AttributeArgument(
+                    ParseExpression(
+                        $"SkipEnabledCheck = {configuration.GenerateSkipEnabledCheck.ToLowerBooleanString()}"))
+            });
+
+        if (configuration.DefaultEventId is not null)
+        {
+            attributeArguments = attributeArguments.Add(
+                AttributeArgument(
+                    ParseExpression($"EventId = {configuration.DefaultEventId.Value.Id}")
+                )
+            );
+            attributeArguments = attributeArguments.Add(
+                AttributeArgument(
+                    ParseExpression($"EventName = \"{configuration.DefaultEventId.Value.Name}\"")
+                )
+            );
+        }
+
         var attribute = Attribute(ParseName(LoggerMessageAttributeName))
             .WithArgumentList(
                 AttributeArgumentList(
-                    SeparatedList(new[]
-                    {
-                        AttributeArgument(
-                            ParseExpression(
-                                $"Level = {Constants.DefaultLoggingNamespace}.LogLevel.{logMessageCall.LogLevel}")),
-                        AttributeArgument(
-                            AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                                IdentifierName("Message"),
-                                LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(logMessageCall.Message)))),
-                        AttributeArgument(
-                            ParseExpression(
-                                $"SkipEnabledCheck = {configuration.GenerateSkipEnabledCheck.ToLowerBooleanString()}"))
-                    })
+                    SeparatedList(attributeArguments)
                 )
             );
 

--- a/tests/AutoLoggerMessageGenerator.UnitTests/VirtualLoggerMessage/VirtualLoggerMessageClassBuilderTests.Build_WithDifferentConfiguration_ShouldReturnLegitLoggerMessageDeclaration_with_empty_event_id.verified.txt
+++ b/tests/AutoLoggerMessageGenerator.UnitTests/VirtualLoggerMessage/VirtualLoggerMessageClassBuilderTests.Build_WithDifferentConfiguration_ShouldReturnLegitLoggerMessageDeclaration_with_empty_event_id.verified.txt
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Extensions.Logging.AutoLoggerMessage
+{
+    static partial class AutoLoggerMessage
+    {
+        // <LogMessageCallMappingLocation>: Guid_1
+        [Microsoft.Extensions.Logging.LoggerMessageAttribute(Level = Microsoft.Extensions.Logging.LogLevel.Critical, Message = "Hello, World!", SkipEnabledCheck = false, EventId = 0, EventName = "")]
+        internal static partial void Log_SomeNamespace_SomeClass_Method_2_22(Microsoft.Extensions.Logging.ILogger Logger, int @intParam, string @stringParam, bool @boolParam, SomeClass @classParam, SomeStruct @structParam);
+        // <LogMessageCallMappingLocation>: Guid_2
+        [Microsoft.Extensions.Logging.LoggerMessageAttribute(Level = Microsoft.Extensions.Logging.LogLevel.Trace, Message = "Goodbye, World!", SkipEnabledCheck = false, EventId = 0, EventName = "")]
+        internal static partial void Log_SomeNamespace_SomeClass_Method_3_33(Microsoft.Extensions.Logging.ILogger Logger, int @intParam, string @stringParam, bool @boolParam, SomeClass @classParam, SomeStruct @structParam);
+    }
+}

--- a/tests/AutoLoggerMessageGenerator.UnitTests/VirtualLoggerMessage/VirtualLoggerMessageClassBuilderTests.cs
+++ b/tests/AutoLoggerMessageGenerator.UnitTests/VirtualLoggerMessage/VirtualLoggerMessageClassBuilderTests.cs
@@ -119,5 +119,16 @@ internal class VirtualLoggerMessageClassBuilderTests
                 GenerateTransitive: false,
                 OverrideBeginScopeBehavior: false),
             false),
+        () => (
+            "with_empty_event_id",
+            new SourceGeneratorConfiguration(
+                GenerateInterceptorAttribute: false,
+                GenerateSkipEnabledCheck: false,
+                GenerateOmitReferenceName: false,
+                GenerateSkipNullProperties: false,
+                GenerateTransitive: false,
+                OverrideBeginScopeBehavior: false,
+                DefaultEventId: new EventId(0, null)),
+            false),
     ];
 }


### PR DESCRIPTION
Added two new configuration options that allow overriding the default event ID when one is not explicitly provided:
* **DefaultEventId** specifies the default event ID to use.
* **DefaultEventId_Name** specifies the default event ID name.

These options allow applications to configure fallback event identifiers without requiring them to be specified for every event.
